### PR TITLE
Fix uninitialized value warns when reading bad DOM fragments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+*.swp
+MYMETA.json
+MYMETA.yml
+Makefile
+blib/
+cover_db/
+pm_to_blib
+Makefile.old

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -33,6 +33,7 @@ WriteMakefile(
         # used in testing
         'Test::Builder::Tester' => '0',
         'Test::More'            => '0.70',
+        'Test::NoWarnings'      => '1.04',
 
     },
 

--- a/lib/Test/XHTML/WAI.pm
+++ b/lib/Test/XHTML/WAI.pm
@@ -300,10 +300,12 @@ sub _check_form_control {
     #    return;
 
     } elsif(!$tag->[1]{title}) {
+        # Attempt to identify by name, ID, full tag dump, then fallback to 'unknown' if they all are falsey.
+        my $identifier = $tag->[1]{name} || $tag->[1]{id} || $tag->[3] || "Unknown Element";
         push @{ $self->{ERRORS} }, {
             ref     => 'WCAG v2 1.1.1 (A)', #E866
             error   => "W003",
-            message => "all <$tag->[0]> tags require a <label> or a title attribute ($tag->[1]{name})",
+            message => "all <$tag->[0]> tags require a <label> or a title attribute ($identifier)",
             row     => $tag->[4],
             col     => $tag->[5]
         };
@@ -526,10 +528,11 @@ sub _check_labelling {
         next    if($self->{input}{$input}{title});
         #next    if($self->{input}{$input}{active} == 0);
 
+        my $type = $self->{input}{$input}{type} || 'input';
         push @{ $self->{ERRORS} }, {
             ref     => 'WCAG v2 1.1.1 (A)', #E866
             error   => "W014",
-            message => "all <$self->{input}{$input}{type}> tags require a unique <label> tag or a title attribute ($input)",
+            message => "all <$type> tags require a unique <label> tag or a title attribute ($input)",
             row     => $self->{input}{$input}{row},
             col     => $self->{input}{$input}{column}
         };

--- a/t/20xmlstrings.t
+++ b/t/20xmlstrings.t
@@ -32,6 +32,9 @@ SKIP: {
 }
 
 # crude, but it'll hopefully do ;)
+# XXX Will fail if user doesn't have direct access to interface (ICMP ping requires this),
+# so most people will see a SKIP from this for *that* reason.
+# Another problem -- it seems that as of 2017, the site explicitly drops ICMP (probably as DDOS prevention).
 sub pingtest {
   system("ping -q -c 1 www.w3c.org >/dev/null 2>&1");
   my $retcode = $? >> 8;

--- a/t/30xmlwaicheck.t
+++ b/t/30xmlwaicheck.t
@@ -1,0 +1,69 @@
+#!/usr/bin/perl -w
+use strict;
+use warnings;
+
+# + 1 for Test::NoWarnings
+use Test::More tests => 2 + 1;
+use Test::XHTML::WAI;
+use Test::NoWarnings;
+use IO::File;
+
+# Error path #1: Inputs with no names, types, anchors without identifiers or titles
+# https://github.com/barbie/test-xhtml/issues/2
+my $txw = Test::XHTML::WAI->new();
+my $content = read_file('./t/samples/test04.html');
+$txw->validate($content);
+my $result = $txw->results();
+my $model = { 'FAIL' => 1, 'PASS' => 0 };
+is_deeply( $result, $model, "WAI compliance check for WCAG violations - FAIL");
+my $errors = $txw->errors();
+$model = [
+    {
+        'col' => 3,
+        'error' => 'W003',
+        'message' => 'all <input> tags require a <label> or a title attribute (undefType)',
+        'ref' => 'WCAG v2 1.1.1 (A)',
+        'row' => 12
+    },
+    {
+        'col' => 3,
+        'error' => 'W003',
+        'message' => 'all <input> tags require a <label> or a title attribute (<input style="display:none" />)',
+        'ref' => 'WCAG v2 1.1.1 (A)',
+        'row' => 13
+    },
+    {
+        'col' => 2,
+        'error' => 'W001',
+        'message' => 'no submit button in form (testForm)',
+        'ref' => 'WCAG v2 3.2.2 (A)',
+        'row' => 14
+    },
+    {
+        'col' => 4,
+        'error' => 'W007',
+        'message' => 'no title attribute in a tag (https://www.youtube.com/watch?v=dQw4w9WgXcQ, \'<a href="https://www.youtube.com/watch?v=dQw4w9WgXcQ">\')',
+        'ref' => 'WCAG v2 1.1.1 (A)',
+        'row' => 17
+    },
+    {
+        'col' => 3,
+        'error' => 'W014',
+        'message' => 'all <input> tags require a unique <label> tag or a title attribute (undefType)',
+        'ref' => 'WCAG v2 1.1.1 (A)',
+        'row' => 11
+    }
+];
+is_deeply( $errors, $model, "...and we got the expected errors" );
+
+# copied from 20xmlstrings.t
+sub read_file {
+    my $file = shift;
+    my $text;
+
+    my $fh = IO::File->new($file,'r')  or die "Cannot open file [$file]: $!\n";
+    while(<$fh>) { $text .= $_; }
+    $fh->close;
+
+    return $text;
+}

--- a/t/samples/test04.html
+++ b/t/samples/test04.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>Test Page 01</title>
+ </head>
+
+ <body>
+  <h1>FORM TEST</h1>
+  <p>I'm a form element, short and stout.</p>
+  <form id="testForm">
+   <input id="undefType" />
+   <input name="undefType" />
+   <input style="display:none" />
+  </form>
+  <div id="footer">
+   <p>
+    <a href="https://www.youtube.com/watch?v=dQw4w9WgXcQ">Help Link</a>
+   </p>
+  </div>
+ </body>
+</html>


### PR DESCRIPTION
fixes issue #2: Just adds fallbacks for when things aren't set.
Additionally:
* Adds some .gitignore rules for things that got generated while
  writing and testing the fix.
* Added a comment about the pingtest skipping more than it probably
  should (not sure on why that is there/proper solution).
* Added dependency for Test::NoWarnings to Makefile.PL, as I use it in
  the test I added.